### PR TITLE
Correciones 1 profesor

### DIFF
--- a/exercise/src/main/java/co/edu/etitc/sistemas/tecnologo/programacion4/Computador.java
+++ b/exercise/src/main/java/co/edu/etitc/sistemas/tecnologo/programacion4/Computador.java
@@ -2,7 +2,6 @@ package co.edu.etitc.sistemas.tecnologo.programacion4;
 
 import java.time.LocalDateTime;
 
-
 public class Computador extends Recurso {
     private String marca;
     private TipoComputador tipo;
@@ -14,9 +13,17 @@ public class Computador extends Recurso {
         this.tipo = tipo;
     }
 
-     @Override
+    public String getMarca() {
+        return marca;
+    }
+
+    public TipoComputador getTipo() {
+        return tipo;
+    }
+
+    @Override
     public boolean coincideConCriterio(String criterio) {
-        if (super.coincideConCriterio(criterio)) { 
+        if (super.coincideConCriterio(criterio)) {
             return true;
         }
 
@@ -28,7 +35,6 @@ public class Computador extends Recurso {
             || tipo.toString().contains(criterio);
     }
 
-
     @Override
     public String toString() {
         return super.toString()
@@ -36,3 +42,4 @@ public class Computador extends Recurso {
             + "tipo=" + tipo + "\n";
     }
 }
+

--- a/exercise/src/main/java/co/edu/etitc/sistemas/tecnologo/programacion4/Computador.java
+++ b/exercise/src/main/java/co/edu/etitc/sistemas/tecnologo/programacion4/Computador.java
@@ -14,19 +14,20 @@ public class Computador extends Recurso {
         this.tipo = tipo;
     }
 
-    @Override
+     @Override
     public boolean coincideConCriterio(String criterio) {
+        if (super.coincideConCriterio(criterio)) { 
+            return true;
+        }
+
         if (criterio == null || criterio.isEmpty()) {
             return false;
         }
- 
-        if (titulo.contains(criterio)
-            || marca.contains(criterio)
-            || tipo.toString().contains(criterio)) {
-            return true;
-        }
-        return false;
+
+        return marca.contains(criterio)
+            || tipo.toString().contains(criterio);
     }
+
 
     @Override
     public String toString() {

--- a/exercise/src/main/java/co/edu/etitc/sistemas/tecnologo/programacion4/Libro.java
+++ b/exercise/src/main/java/co/edu/etitc/sistemas/tecnologo/programacion4/Libro.java
@@ -2,7 +2,6 @@ package co.edu.etitc.sistemas.tecnologo.programacion4;
 
 import java.time.LocalDateTime;
 
-
 public class Libro extends Recurso {
     private String autor;
     private String editorial;
@@ -10,17 +9,27 @@ public class Libro extends Recurso {
 
     public Libro(String titulo, LocalDateTime fechaIngreso, boolean activo,
                  String autor, String editorial, int año) {
-
         super(titulo, fechaIngreso, activo);
         this.autor = autor;
         this.editorial = editorial;
         this.año = año;
     }
 
+    public String getAutor() {
+        return autor;
+    }
 
-   @Override
+    public String getEditorial() {
+        return editorial;
+    }
+
+    public int getAño() {
+        return año;
+    }
+
+    @Override
     public boolean coincideConCriterio(String criterio) {
-        if (super.coincideConCriterio(criterio)) { 
+        if (super.coincideConCriterio(criterio)) {
             return true;
         }
 
@@ -33,13 +42,12 @@ public class Libro extends Recurso {
             || String.valueOf(año).contains(criterio);
     }
 
-
     @Override
     public String toString() {
-  
         return super.toString()
             + "autor=" + autor + "\n"
             + "editorial=" + editorial + "\n"
             + "año=" + año + "\n";
     }
 }
+

--- a/exercise/src/main/java/co/edu/etitc/sistemas/tecnologo/programacion4/Libro.java
+++ b/exercise/src/main/java/co/edu/etitc/sistemas/tecnologo/programacion4/Libro.java
@@ -18,19 +18,19 @@ public class Libro extends Recurso {
     }
 
 
-    @Override
+   @Override
     public boolean coincideConCriterio(String criterio) {
+        if (super.coincideConCriterio(criterio)) { 
+            return true;
+        }
+
         if (criterio == null || criterio.isEmpty()) {
             return false;
         }
 
-        if (titulo.contains(criterio)
-            || autor.contains(criterio)
+        return autor.contains(criterio)
             || editorial.contains(criterio)
-            || String.valueOf(año).contains(criterio)) {
-            return true;
-        }
-        return false;
+            || String.valueOf(año).contains(criterio);
     }
 
 

--- a/exercise/src/main/java/co/edu/etitc/sistemas/tecnologo/programacion4/Periodico.java
+++ b/exercise/src/main/java/co/edu/etitc/sistemas/tecnologo/programacion4/Periodico.java
@@ -16,16 +16,16 @@ public class Periodico extends Recurso {
 
     @Override
     public boolean coincideConCriterio(String criterio) {
+        if (super.coincideConCriterio(criterio)) {
+            return true;
+        }
+
         if (criterio == null || criterio.isEmpty()) {
             return false;
         }
 
-        if (titulo.contains(criterio)
-            || editorial.contains(criterio)
-            || fechaPublicacion.toString().contains(criterio)) {
-            return true;
-        }
-        return false;
+        return editorial.contains(criterio)
+            || fechaPublicacion.toString().contains(criterio);
     }
 
     @Override

--- a/exercise/src/main/java/co/edu/etitc/sistemas/tecnologo/programacion4/Periodico.java
+++ b/exercise/src/main/java/co/edu/etitc/sistemas/tecnologo/programacion4/Periodico.java
@@ -2,7 +2,6 @@ package co.edu.etitc.sistemas.tecnologo.programacion4;
 
 import java.time.LocalDateTime;
 
-
 public class Periodico extends Recurso {
     private String editorial;
     private LocalDateTime fechaPublicacion;
@@ -12,6 +11,14 @@ public class Periodico extends Recurso {
         super(titulo, fechaIngreso, activo);
         this.editorial = editorial;
         this.fechaPublicacion = fechaPublicacion;
+    }
+
+    public String getEditorial() {
+        return editorial;
+    }
+
+    public LocalDateTime getFechaPublicacion() {
+        return fechaPublicacion;
     }
 
     @Override
@@ -35,3 +42,4 @@ public class Periodico extends Recurso {
             + "fechaPublicacion=" + fechaPublicacion + "\n";
     }
 }
+

--- a/exercise/src/main/java/co/edu/etitc/sistemas/tecnologo/programacion4/Recurso.java
+++ b/exercise/src/main/java/co/edu/etitc/sistemas/tecnologo/programacion4/Recurso.java
@@ -4,9 +4,9 @@ import java.time.LocalDateTime;
 
 
 public abstract class Recurso {
-    protected String titulo;         
-    protected LocalDateTime fechaIngreso; 
-    protected boolean activo;        
+    private String titulo;         
+    private LocalDateTime fechaIngreso; 
+    private boolean activo;        
 
 
     public Recurso(String titulo, LocalDateTime fechaIngreso, boolean activo) {


### PR DESCRIPTION
@jlhuerfanor
Todos los atributos de clase deben ser privados (ver  diagrama): 



La clase Recurso debe definir la coincidencia por nombre y fechaIngreso. Las clases que heredan de ella deben sobrecargar el método e incluir los atributos adicionales que definan:


Faltan getters en todas las clases
